### PR TITLE
feat: swagger 및 프로젝트 설정

### DIFF
--- a/zupzup/zupzup/build.gradle
+++ b/zupzup/zupzup/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// 기타
 	implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/ZupzupApplication.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/ZupzupApplication.java
@@ -1,12 +1,10 @@
 package com.MOA.zupzup;
 
-import com.MOA.zupzup.login.FirebaseConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication
 public class ZupzupApplication {
 
     public static void main(String[] args) {

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/FirebaseConfig.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/FirebaseConfig.java
@@ -1,4 +1,4 @@
-package com.MOA.zupzup.login;
+package com.MOA.zupzup.global;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.PostConstruct;
 import java.io.FileInputStream;
 import java.io.IOException;
 

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/FirebaseStorageService.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/FirebaseStorageService.java
@@ -1,4 +1,4 @@
-package com.MOA.zupzup.login;
+package com.MOA.zupzup.global;
 
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Bucket;

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/SwaggerConfig.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/SwaggerConfig.java
@@ -1,17 +1,9 @@
-package com.MOA.zupzup.login;
+package com.MOA.zupzup.global;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
-import org.springdoc.core.models.GroupedOpenApi;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -25,8 +17,7 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("CareLink")
-                .description("CareLink API Documentation")
+                .title("줍줍")
                 .version("1.0.0");
     }
 }

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/ErrorCode.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.MOA.zupzup.exception;
+package com.MOA.zupzup.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/ErrorResponse.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.MOA.zupzup.exception;
+package com.MOA.zupzup.global.exception;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/GlobalExceptionHandler.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.MOA.zupzup.exception;
+package com.MOA.zupzup.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/LetterException.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/global/exception/LetterException.java
@@ -1,4 +1,4 @@
-package com.MOA.zupzup.exception;
+package com.MOA.zupzup.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/zupzup/zupzup/src/main/java/com/MOA/zupzup/letter/LetterService.java
+++ b/zupzup/zupzup/src/main/java/com/MOA/zupzup/letter/LetterService.java
@@ -1,7 +1,7 @@
 package com.MOA.zupzup.letter;
 
-import com.MOA.zupzup.exception.ErrorCode;
-import com.MOA.zupzup.exception.LetterException;
+import com.MOA.zupzup.global.exception.ErrorCode;
+import com.MOA.zupzup.global.exception.LetterException;
 import com.MOA.zupzup.letter.dto.DroppingLetterRequest;
 import com.MOA.zupzup.letter.dto.LetterResponse;
 import com.google.api.core.ApiFuture;

--- a/zupzup/zupzup/src/test/java/com/MOA/zupzup/letter/LetterServiceTest.java
+++ b/zupzup/zupzup/src/test/java/com/MOA/zupzup/letter/LetterServiceTest.java
@@ -1,9 +1,11 @@
 package com.MOA.zupzup.letter;
 
+import com.MOA.zupzup.global.exception.LetterException;
 import com.MOA.zupzup.letter.dto.DroppingLetterRequest;
 import com.MOA.zupzup.letter.dto.LetterResponse;
-import com.MOA.zupzup.login.FirebaseConfig;
+import com.MOA.zupzup.global.FirebaseConfig;
 import com.google.cloud.firestore.GeoPoint;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,6 +60,13 @@ public class LetterServiceTest {
         LetterResponse response = letterService.findLetter(savedId);
         System.out.println("Receiver : " + response.receiverId());
         assertNotNull(String.valueOf(response.id()), "편지 찾을 수 없음");
+    }
+
+    @Test
+    void 편지_줍기_에러_발생() {
+        Assertions.assertThrows(LetterException.class, () -> {
+            letterService.pickUpLetter("123", "who");
+        });
     }
 }
 


### PR DESCRIPTION
- 파이어베이스 관련 파일, SwaggerConfig 파일이 login 패키지에 있었는데 login하고 맞진 않는거 같아서 global 패키지 만들어서 담았습니다. 에러 패키지도 이 안에 넣었어요
- @SpringBootApplication 어노테이션에서 (exclude = {SecurityAutoConfiguration.class}) 옵션은 보통 security 의존성 사용 시 인증이 아직 구현되기 전에 쓰려고 다는 걸로 알고 있는데 저희는 이제 security 안쓰니까 빼도 될 것 같습니다
- build.gradle에서 swagger 의존성을 다른 의존성이랑 같은 형식으로 쓰는게 좋을 것 같아 수정했습니다.
- Swagger 제목 줍줍으로 바꿨습니다

close #15 